### PR TITLE
이미지 url 관련 에러 처리

### DIFF
--- a/script/background.js
+++ b/script/background.js
@@ -9,9 +9,14 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       return true;
     case "isAd":
       const { url } = request;
-      checkIsAd(url).then((isAd) => {
-        sendResponse(isAd);
-      });
+      checkIsAd(url)
+        .then((isAd) => {
+          sendResponse(isAd);
+        })
+        .catch((err) => {
+          console.log(err);
+          sendResponse("error");
+        });
       return true;
     default:
       return false;

--- a/script/contentscript.js
+++ b/script/contentscript.js
@@ -1,4 +1,5 @@
 const removeComponent = async (component, url, option) => {
+  if (url === "") return;
   const isAd = await chrome.runtime.sendMessage({
     option: "isAd",
     url: url,

--- a/script/contentscript.js
+++ b/script/contentscript.js
@@ -1,5 +1,5 @@
 const removeComponent = async (component, url, option) => {
-  if (url === "") return;
+  if (!url) return;
   const isAd = await chrome.runtime.sendMessage({
     option: "isAd",
     url: url,

--- a/script/contentscript.js
+++ b/script/contentscript.js
@@ -23,9 +23,19 @@ const removeAds = () => {
   // div 태그 제거
   let divs = document.querySelectorAll("div");
   divs.forEach((div) => {
-    const divSrc = div.attributes.getNamedItem("data-imgsrc");
-    if (divSrc) {
-      removeComponent(div, divSrc.value, "div");
+    const divImgSrc = div.attributes.getNamedItem("data-imgsrc");
+    if (divImgSrc) {
+      removeComponent(div, divImgSrc.value, "div");
+      return;
+    }
+    const divBgImg = div.style.backgroundImage;
+    if (divBgImg) {
+      const divBgImgSrc = divBgImg.split('"')[1];
+      // https가 생략된 경우에 대한 처리
+      divBgImgSrc && divBgImgSrc.startsWith("//")
+        ? removeComponent(div, "https:" + divBgImgSrc, "div")
+        : removeComponent(div, divBgImgSrc, "div");
+      return;
     }
   });
 };

--- a/script/contentscript.js
+++ b/script/contentscript.js
@@ -23,9 +23,9 @@ const removeAds = () => {
   // div 태그 제거
   let divs = document.querySelectorAll("div");
   divs.forEach((div) => {
-    const divSrc = div.style.backgroundImage.split('"')[1];
+    const divSrc = div.attributes.getNamedItem("data-imgsrc");
     if (divSrc) {
-      removeComponent(div, divSrc, "div");
+      removeComponent(div, divSrc.value, "div");
     }
   });
 };

--- a/script/utils.js
+++ b/script/utils.js
@@ -16,8 +16,15 @@ export const checkCurrentTabUrl = async () => {
 
 export const checkIsAd = async (url) => {
   try {
-    const requestUrl = APIURL + "?url=" + url;
-    const response = await fetch(requestUrl);
+    const response = await fetch(APIURL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        url: url,
+      }),
+    });
     const result = await response.json();
     return result.class === "ad" ? true : false;
   } catch (error) {

--- a/script/utils.js
+++ b/script/utils.js
@@ -19,6 +19,7 @@ export const checkIsAd = async (url) => {
     const response = await fetch(APIURL, {
       method: "POST",
       headers: {
+        Accept: "application/json",
         "Content-Type": "application/json",
       },
       body: JSON.stringify({


### PR DESCRIPTION
이미지 url로 인해 발생하던 에러 처리함

- url이 유효하지 않은 경우 요청 보내지 않게 함
- div 태그의 data-imgsrc의 값에서 이미지 url 받아오기
- https가 생략된 경우 url 요청에 https prefix 붙이기
- api method get에서 post로 변경
- 에러 응답에 대한 처리 추가